### PR TITLE
Add `htmlSafe` and `isHTMLSafe` exported methods. These will error when called, telling the user to import from `@ember/template`.

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -3,6 +3,7 @@
  @module @ember/string
  */
 import Cache from './cache';
+import { deprecate } from '@ember/debug';
 
 // STATE within a module is frowned upon, this exists
 // to support Ember.STRINGS but shield ember internals from this legacy global
@@ -249,4 +250,23 @@ export function underscore(str: string): string {
 */
 export function capitalize(str: string): string {
   return CAPITALIZE_CACHE.get(str);
+}
+
+/*
+  The following are implemented here to give users adding `@ember/string` to
+  their projects a useful error message. The `ember-source` implementation of
+  `@ember/string` is clobbered by adding this addon, and so the deprecation of
+  the import path is not triggered. This error message is intended to help
+  users discover what they need to change.
+*/
+export function htmlSafe(str: string): void {
+  throw new Error(
+    'htmlSafe is not implemented in the `@ember/string` package. Please import from `@ember/template` instead.'
+  );
+}
+
+export function isHTMLSafe(str: any | null | undefined): void {
+  throw new Error(
+    'isHTMLSafe is not implemented in the `@ember/string` package. Please import from `@ember/template` instead.'
+  );
 }


### PR DESCRIPTION
When this addon is added to a project it clobbers the internal to ember-source `@ember/string` and thus deprecations thrown by the implementation there. Adding these courtesy exceptions will help users understand how to change their code when adding this addon.