### PR TITLE
Ship own types (copy from DT)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -44,9 +44,7 @@ jobs:
     strategy:
       matrix:
         tsVersion:
-          - 4.4
-          - 4.6
-          - 4.8
+          - 4.9
           - 5.0
           - 5.1
     steps:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -46,7 +46,7 @@ jobs:
         tsVersion:
           - '~4.9'
           - '~5.0'
-          - '~5.1'
+          - 'beta'
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -44,9 +44,9 @@ jobs:
     strategy:
       matrix:
         tsVersion:
-          - 4.9
-          - 5.0
-          - 5.1
+          - '~4.9'
+          - '~5.0'
+          - '~5.1'
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: install dependencies
         run: yarn install --frozen-lockfile
       - name: Swap TS Version
-        run: yarn add --dev typescript@{{ matrix.tsVersion }}
+        run: yarn add --dev typescript@${{ matrix.tsVersion }}
       - name: Check Types
         run: |
           tsc -v

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -36,6 +36,31 @@ jobs:
       - run: yarn install --no-lockfile
       - run: yarn test:ember
 
+  types-scenarios:
+    name: "Types: ${{ matrix.tsVersion }}"
+    runs-on: ubuntu-latest
+    needs: test
+
+    strategy:
+      matrix:
+        tsVersion:
+          - 4.4
+          - 4.6
+          - 4.8
+          - 5.0
+          - 5.1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
+      - name: install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Swap TS Version
+        run: yarn add --dev typescript@{{ matrix.tsVersion }}
+      - name: Check Types
+        run: |
+          tsc -v
+          yarn test:types
+
   try-scenarios:
     name: "Try: ${{ matrix.ember-try-scenario }}"
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -56,7 +56,7 @@ jobs:
         run: yarn add --dev typescript@${{ matrix.tsVersion }}
       - name: Check Types
         run: |
-          tsc -v
+          yarn tsc -v
           yarn test:types
 
   try-scenarios:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -50,6 +50,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
+        with:
+          # TS 5.1 does not support node 12
+          node-version: 14.x
       - name: install dependencies
         run: yarn install --frozen-lockfile
       - name: Swap TS Version

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+export function camelize(str: string): string;
+export function capitalize(str: string): string;
+export function classify(str: string): string;
+export function dasherize(str: string): string;
+export function decamelize(str: string): string;
+export function underscore(str: string): string;
+export function w(str: string): string[];

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-qunit": "^7.3.4",
+    "expect-type": "^0.15.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "start": "ember serve",
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test",
+    "test:types": "tsc --noEmit --project ./type-tests/tsconfig.json",
     "test:ember-compatibility": "ember try:each",
     "test-typings": "node node_modules/typescript/bin/tsc",
     "prepack": "yarn babel --extensions '.ts' --presets @babel/preset-typescript addon --out-dir addon/ --ignore '**/*.d.ts'",
@@ -42,6 +43,7 @@
     "@embroider/test-setup": "^0.47.1",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
+    "@tsconfig/ember": "^2.0.0",
     "@types/ember": "^3.16.5",
     "@types/ember-qunit": "^3.4.14",
     "@types/ember__test-helpers": "^2.0.2",
@@ -84,7 +86,7 @@
     "release-it": "^14.11.6",
     "release-it-lerna-changelog": "^3.1.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.4.4",
+    "typescript": "^5.0.4",
     "webpack": "^5"
   },
   "engines": {

--- a/type-tests/the-tests.ts
+++ b/type-tests/the-tests.ts
@@ -15,7 +15,7 @@ dasherize();
 // @ts-expect-error
 dasherize('', '');
 
-expectTypeOf(dasherize('blue man group')).toBeString()
+expectTypeOf(dasherize('blue man group')).toBeString();
 
 // @ts-expect-error
 camelize();

--- a/type-tests/the-tests.ts
+++ b/type-tests/the-tests.ts
@@ -8,44 +8,53 @@ import {
   w,
 } from '@ember/string';
 
+import { expectTypeOf } from 'expect-type';
+
 // @ts-expect-error
 dasherize();
-dasherize('blue man group'); // $ExpectType string
 // @ts-expect-error
 dasherize('', '');
 
+expectTypeOf(dasherize('blue man group')).toBeString()
+
 // @ts-expect-error
 camelize();
-camelize('blue man group'); // $ExpectType string
 // @ts-expect-error
 camelize('', '');
 
+expectTypeOf(camelize('blue man group')).toBeString();
+
 // @ts-expect-error
 decamelize();
-decamelize('blue man group'); // $ExpectType string
 // @ts-expect-error
 decamelize('', '');
 
+expectTypeOf(decamelize('blue man group')).toBeString();
+
 // @ts-expect-error
 underscore();
-underscore('blue man group'); // $ExpectType string
 // @ts-expect-error
 underscore('', '');
 
+expectTypeOf(underscore('blue man group')).toBeString();
+
 // @ts-expect-error
 w();
-w('blue man group'); // $ExpectType string[]
 // @ts-expect-error
 w('', '');
 
+expectTypeOf(w('blue man group')).toMatchTypeOf<string[]>();
+
 // @ts-expect-error
 classify();
-classify('blue man group'); // $ExpectType string
 // @ts-expect-error
 classify('', '');
 
+expectTypeOf(classify('blue man group')).toBeString();
+
 // @ts-expect-error
 capitalize();
-capitalize('blue man group'); // $ExpectType string
 // @ts-expect-error
 capitalize('', '');
+
+expectTypeOf(capitalize('blue man group')).toBeString();

--- a/type-tests/the-tests.ts
+++ b/type-tests/the-tests.ts
@@ -1,0 +1,51 @@
+import {
+  dasherize,
+  camelize,
+  capitalize,
+  classify,
+  decamelize,
+  underscore,
+  w,
+} from '@ember/string';
+
+// @ts-expect-error
+dasherize();
+dasherize('blue man group'); // $ExpectType string
+// @ts-expect-error
+dasherize('', '');
+
+// @ts-expect-error
+camelize();
+camelize('blue man group'); // $ExpectType string
+// @ts-expect-error
+camelize('', '');
+
+// @ts-expect-error
+decamelize();
+decamelize('blue man group'); // $ExpectType string
+// @ts-expect-error
+decamelize('', '');
+
+// @ts-expect-error
+underscore();
+underscore('blue man group'); // $ExpectType string
+// @ts-expect-error
+underscore('', '');
+
+// @ts-expect-error
+w();
+w('blue man group'); // $ExpectType string[]
+// @ts-expect-error
+w('', '');
+
+// @ts-expect-error
+classify();
+classify('blue man group'); // $ExpectType string
+// @ts-expect-error
+classify('', '');
+
+// @ts-expect-error
+capitalize();
+capitalize('blue man group'); // $ExpectType string
+// @ts-expect-error
+capitalize('', '');

--- a/type-tests/tsconfig.json
+++ b/type-tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@tsconfig/ember",
+  "compilerOptions": {
+    "paths": {
+      "@ember/string": ["../"]
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,6 +1774,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tsconfig/ember@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tsconfig/ember/-/ember-2.0.0.tgz#dba953e5527ccf7a2587f262a7afe0fa83c4e979"
+  integrity sha512-RzbDYYcjxVdG8Ki0xe99HN3+nHTZe6EBgw6N7B3yup7QogVFQQxA9nY7X80j1XzF15xqetwWiYfAjv5lkkp0/A==
+
 "@types/body-parser@*":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.1.tgz#0c0174c42a7d017b818303d4b5d969cb0b75929c"
@@ -12499,10 +12504,10 @@ typescript-memoize@^1.0.0-alpha.3:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.1.tgz#0a8199aa28f6fe18517f6e9308ef7bfbe9a98d59"
   integrity sha512-oJNge1qUrOK37d5Y6Ly2txKeuelYVsFtNF6U9kXIN7juudcQaHJQg2MxLOy0CqtkW65rVDYuTCOjnSIVPd8z3w==
 
-typescript@^4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6365,6 +6365,11 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
+expect-type@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-0.15.0.tgz#89f75e22c88554844ea2b2faf4ef5fc2e579d3b5"
+  integrity sha512-yWnriYB4e8G54M5/fAFj7rCIBiKs1HAACaY13kCz6Ku0dezjS9aMcfcdVK2X8Tv2tEV1BPz/wKfQ7WA4S/d8aA==
+
 express@^4.10.7, express@^4.17.1:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"


### PR DESCRIPTION
Copies the types and type-tests from DT, here: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/ember__string

This PR enables folks using `ember-source@v5` to use the built-in types and not have to install `@types/ember__string`
prior to ember-source@v5, the types for ember-string were here: https://github.com/emberjs/ember.js/blob/v4.12.0/types/preview/%40ember/string/index.d.ts

but `ember-source@v5` removed `@ember/string`, per deprecation plan.