### PR TITLE
Do not exclude `.d.ts` in `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -36,13 +36,10 @@
 /package.json.ember-try
 
 # typescript
-#
-# avoid publishing .d.ts or .ts files
-# until they have become enforced "public" APIs
-*.ts
-# to enable d.ts consumption remove the next line
-# !*.d.ts
+!*.d.ts
 !addon/**/*.js
+
+# miscellanies
 server/
 tsconfig.json
 *.tgz


### PR DESCRIPTION
This will make the attempt to publish types (3.1.0) actually work.