### PR TITLE
Manually tell CI to use pnpm 9 everywhere

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -54,19 +54,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      
+
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
       - run: pnpm install --frozen-lockfile
-      
+
       - name: "Generate Explanation and Prep Changelogs"
         id: explanation
         run: |
           set +e
-          
+
           pnpm release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)
-          
+
 
           if [ $? -ne 0 ]; then
             echo 'text<<EOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,14 +49,14 @@ jobs:
           node-version: 18
           # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
           registry-url: 'https://registry.npmjs.org'
-      
+
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
       - run: pnpm install --frozen-lockfile
       - name: npm publish
         run: pnpm release-plan publish
-      
+
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
If only there were a CI config that understood how to read package.json :thinking: 

https://github.com/wyvox/action-setup-pnpm  :p

Related: https://github.com/embroider-build/create-release-plan-setup/issues/111